### PR TITLE
Ensure Flask model loads on import

### DIFF
--- a/4-machine-learning-engineer/ml_python/app/app.py
+++ b/4-machine-learning-engineer/ml_python/app/app.py
@@ -1,8 +1,16 @@
 from flask import Flask, request, jsonify
 import joblib
 import pandas as pd
+import os
 
 app = Flask(__name__)
+
+# Load the trained model once when the application starts. Using an
+# absolute path ensures the model can be located regardless of the
+# working directory from which the app is launched (e.g. via ``flask``
+# CLI or a WSGI server).
+MODEL_PATH = os.path.join(os.path.dirname(__file__), "model.pkl")
+rf = joblib.load(MODEL_PATH)
 
 @app.route("/")
 def home():
@@ -11,11 +19,10 @@ def home():
 @app.route('/predict', methods=['POST'])
 def predict():
      json_ = request.get_json()
-     query_df = pd.json_normalize(json_)     
+     query_df = pd.json_normalize(json_)
      query = query_df.to_numpy()
      prediction = rf.predict(query)
-     return jsonify({'prediction':prediction.tolist()})
+     return jsonify({'prediction': prediction.tolist()})
 
 if __name__ == '__main__':
-    rf = joblib.load('model.pkl')
-    app.run(host = '0.0.0.0', port=8080)
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- Load trained model at startup using an absolute path so Flask can find it when launched via `flask run` or other WSGI servers.
- Remove runtime model loading from `__main__` block and rely on globally loaded model for predictions.

## Testing
- `python -m py_compile 4-machine-learning-engineer/ml_python/app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689503545f60832cb2878b171a1cad26