### PR TITLE
Fix typos in README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ This repo is a companion site for the course [CORE: Data Science and Machine Lea
     
 </p>
 
-The goal here is very ambitious; to be the only reference site you need on your inital learning journey as a data scientist. Getting started in **data science** is hard. There is an overwhelming number of resources and suggestions. Many people give up!
+The goal here is very ambitious; to be the only reference site you need on your initial learning journey as a data scientist. Getting started in **data science** is hard. There is an overwhelming number of resources and suggestions. Many people give up!
 
 The goal of this road map is to get you started (or re-directed) on your journey the right way with NO knowledge gaps. Everything from original content to linked resources has been vetted through experience and practice. 
 
-Data jobs come in three general flavors (but are often called different things in practice); Data Analyst, General Data Scientist, and Machine Learning Engineer. The skills, course, and resources are divided into these categories for ease of reference. Pay close attentioin to recommended books to add to your library, several are **must reads.**
+Data jobs come in three general flavors (but are often called different things in practice); Data Analyst, General Data Scientist, and Machine Learning Engineer. The skills, course, and resources are divided into these categories for ease of reference. Pay close attention to recommended books to add to your library, several are **must reads.**
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- Correct spelling mistakes in README intro paragraph by replacing "inital" with "initial" and "attentioin" with "attention".

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895045c1c38832c8cc07beba504c393